### PR TITLE
Enable project links for compliance checklist generator

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -106,22 +106,64 @@ const ProjectsSection = () => {
 
                   {/* Actions */}
                   <div className="flex gap-3 pt-4">
-                    <Button 
-                      variant="outline" 
-                      size="sm"
-                      disabled={project.status === "Planning"}
-                    >
-                      <Github className="mr-2 h-4 w-4" />
-                      Code
-                    </Button>
-                    <Button 
-                      size="sm"
-                      disabled={!["Live", "Beta"].includes(project.status)}
-                      className="bg-gradient-to-r from-primary to-gold hover:from-primary-dark hover:to-gold-dark disabled:from-muted disabled:to-muted shadow-gold"
-                    >
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      {project.status === "Live" ? "Try it" : project.status === "Beta" ? "Preview" : "Coming Soon"}
-                    </Button>
+                    {project.githubUrl && project.githubUrl !== "#" ? (
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm">
+                        <a
+                          href={project.githubUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Github className="mr-2 h-4 w-4" />
+                          Code
+                        </a>
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled
+                      >
+                        <Github className="mr-2 h-4 w-4" />
+                        Code
+                      </Button>
+                    )}
+
+                    {project.demoUrl && project.demoUrl !== "#" ? (
+                      <Button
+                        asChild
+                        size="sm"
+                        className="bg-gradient-to-r from-primary to-gold hover:from-primary-dark hover:to-gold-dark disabled:from-muted disabled:to-muted shadow-gold"
+                      >
+                        <a
+                          href={project.demoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          {project.status === "Live"
+                            ? "Try it"
+                            : project.status === "Beta"
+                              ? "Preview"
+                              : "Coming Soon"}
+                        </a>
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        disabled
+                        className="bg-gradient-to-r from-primary to-gold hover:from-primary-dark hover:to-gold-dark disabled:from-muted disabled:to-muted shadow-gold"
+                      >
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        {project.status === "Live"
+                          ? "Try it"
+                          : project.status === "Beta"
+                            ? "Preview"
+                            : "Coming Soon"}
+                      </Button>
+                    )}
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
## Summary
- Activate GitHub and demo buttons using anchor links so project URLs open in new tabs
- Disable buttons only when no URL is provided

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `npx eslint src/components/ProjectsSection.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b220772d2c832d86148ca20b599b9e