### PR TITLE
fix: restore substack sync

### DIFF
--- a/src/components/ArticlesSection.tsx
+++ b/src/components/ArticlesSection.tsx
@@ -53,7 +53,7 @@ const ArticlesSection = () => {
 
       toast({
         title: "Success",
-        description: `${data.message}. Found ${data.articlesProcessed} articles.`,
+        description: `${data.message}. ${data.newArticles} new, ${data.updatedArticles} updated.`,
       });
 
       // Refresh articles after sync


### PR DESCRIPTION
## Summary
- use XML parser and custom user-agent to reliably fetch and parse Substack RSS feed
- show new and updated article counts after syncing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint supabase/functions/sync-substack/index.ts src/components/ArticlesSection.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b234ade1c4832da1c51f60b704541c