### PR TITLE
Cluster-based reports dashboard: nodes are subject clusters, not indi…

### DIFF
--- a/scripts/build-reports.ts
+++ b/scripts/build-reports.ts
@@ -23,9 +23,21 @@ type ManifestEntry = {
   topic: string;
   jurisdiction?: string;
   summary: string;
+  cluster?: string;
+  cluster_slug?: string;
 };
 
-type GeneratedMemo = ManifestEntry & { body: string };
+type GeneratedReport = ManifestEntry & { body: string };
+
+type Cluster = {
+  slug: string;
+  name: string;
+  topic: string;
+  summary: string;
+  reports: string[];
+  dateRange: { first: string; latest: string };
+  jurisdictions: string[];
+};
 
 function normalizeDate(value: unknown): string {
   if (value instanceof Date) return value.toISOString().slice(0, 10);
@@ -65,7 +77,7 @@ async function main() {
     throw new Error("index.json missing 'memos' array");
   }
 
-  const memos: GeneratedMemo[] = [];
+  const memos: GeneratedReport[] = [];
   const slugs = new Set<string>();
 
   for (const entry of manifest.memos) {
@@ -86,6 +98,8 @@ async function main() {
       topic: fm.topic || entry.topic,
       jurisdiction: fm.jurisdiction || entry.jurisdiction || "Unknown",
       summary: fm.summary || entry.summary,
+      cluster: fm.cluster || entry.cluster || "",
+      cluster_slug: fm.cluster_slug || entry.cluster_slug || "",
       body: cleanBody(parsed.content),
     });
     console.log(`[build-reports] + ${entry.slug}`);
@@ -93,9 +107,21 @@ async function main() {
 
   memos.sort((a, b) => (a.date < b.date ? 1 : -1));
 
+  // Fetch clusters.json — tolerate a 404 in case it's the pre-cluster state of the repo
+  let clusters: Cluster[] = [];
+  try {
+    const clustersRaw = await fetchText(`${RAW_BASE}/clusters.json`);
+    clusters = JSON.parse(clustersRaw) as Cluster[];
+    if (!Array.isArray(clusters)) throw new Error("clusters.json is not an array");
+    console.log(`[build-reports] Loaded ${clusters.length} clusters`);
+  } catch (e) {
+    console.warn(`[build-reports] clusters.json unavailable — falling back to empty list: ${e}`);
+    clusters = [];
+  }
+
   fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
-  fs.writeFileSync(OUT_FILE, JSON.stringify({ memos }, null, 2));
-  console.log(`[build-reports] Wrote ${memos.length} memo(s) to ${OUT_FILE}`);
+  fs.writeFileSync(OUT_FILE, JSON.stringify({ memos, clusters }, null, 2));
+  console.log(`[build-reports] Wrote ${memos.length} report(s) and ${clusters.length} cluster(s) to ${OUT_FILE}`);
 }
 
 main().catch((err) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import FTCAnalytics from "./pages/FTCAnalytics";
 import ReportsIndex from "./pages/ReportsIndex";
+import ReportsCluster from "./pages/ReportsCluster";
 import ReportDetail from "./pages/ReportDetail";
 
 const queryClient = new QueryClient();
@@ -21,6 +22,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/FTCAnalytics" element={<FTCAnalytics />} />
           <Route path="/reports" element={<ReportsIndex />} />
+          <Route path="/reports/cluster/:slug" element={<ReportsCluster />} />
           <Route path="/reports/:slug" element={<ReportDetail />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/reports/ReportsGraph.tsx
+++ b/src/components/reports/ReportsGraph.tsx
@@ -2,13 +2,14 @@ import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ReportsGraphTooltip from "./ReportsGraphTooltip";
 
-export type GraphReport = {
+export type GraphCluster = {
   slug: string;
-  title: string;
-  date: string;
+  name: string;
   topic: string;
-  jurisdiction: string;
   summary: string;
+  reports: string[];
+  dateRange: { first: string; latest: string };
+  jurisdictions: string[];
 };
 
 const VIEWBOX_W = 780;
@@ -28,78 +29,65 @@ function hashSlug(slug: string): number {
   return h;
 }
 
-type LaidOut = GraphReport & { x: number; y: number; r: number; color: string };
+type LaidOut = GraphCluster & { x: number; y: number; r: number; color: string };
 
 type HoverState = {
-  report: GraphReport;
+  cluster: GraphCluster;
   clientX: number;
   clientY: number;
 } | null;
 
-export default function ReportsGraph({ reports }: { reports: GraphReport[] }) {
+export default function ReportsGraph({ clusters }: { clusters: GraphCluster[] }) {
   const navigate = useNavigate();
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<HoverState>(null);
 
-  // Distribute reports on their topic's orbit by slug-hash, then count jurisdictional neighbors for size
   const nodes = useMemo<LaidOut[]>(() => {
-    const byTopic: Record<string, GraphReport[]> = {};
-    for (const m of reports) {
-      const key = TOPICS[m.topic] ? m.topic : "privacy";
-      (byTopic[key] ||= []).push(m);
-    }
-
-    const jurCounts: Record<string, number> = {};
-    for (const m of reports) {
-      if (m.jurisdiction && m.jurisdiction !== "Unknown") {
-        jurCounts[m.jurisdiction] = (jurCounts[m.jurisdiction] || 0) + 1;
-      }
+    const byTopic: Record<string, GraphCluster[]> = {};
+    for (const c of clusters) {
+      const key = TOPICS[c.topic] ? c.topic : "privacy";
+      (byTopic[key] ||= []).push(c);
     }
 
     const out: LaidOut[] = [];
     for (const [topic, list] of Object.entries(byTopic)) {
       const cfg = TOPICS[topic];
-      list.forEach((m, i) => {
-        // Stable angle seeded by slug hash, plus small index-based jitter so same-hash collisions spread
-        const hash = hashSlug(m.slug);
+      list.forEach((c, i) => {
+        const hash = hashSlug(c.slug);
         const base = (hash % 360) * (Math.PI / 180);
         const offset = (i * 37) * (Math.PI / 180);
         const angle = base + offset;
         const x = cfg.cx + cfg.radius * Math.cos(angle);
         const y = cfg.cy + cfg.radius * Math.sin(angle);
-        const neighbors = jurCounts[m.jurisdiction] || 1;
-        const r = Math.max(5, Math.min(11, 4 + neighbors * 1.5));
-        out.push({ ...m, x, y, r, color: cfg.color });
+        const r = Math.max(6, Math.min(16, 5 + c.reports.length * 2.5));
+        out.push({ ...c, x, y, r, color: cfg.color });
       });
     }
     return out;
-  }, [reports]);
+  }, [clusters]);
 
-  // Edges: pairs sharing a non-Unknown jurisdiction
+  // Edges: clusters sharing any jurisdiction (excluding "Unknown")
   const edges = useMemo(() => {
     const e: Array<{ a: LaidOut; b: LaidOut }> = [];
     for (let i = 0; i < nodes.length; i++) {
       for (let j = i + 1; j < nodes.length; j++) {
         const a = nodes[i];
         const b = nodes[j];
-        if (
-          a.jurisdiction &&
-          a.jurisdiction !== "Unknown" &&
-          a.jurisdiction === b.jurisdiction
-        ) {
-          e.push({ a, b });
-        }
+        const overlap = a.jurisdictions.some(
+          (j) => j && j !== "Unknown" && b.jurisdictions.includes(j),
+        );
+        if (overlap) e.push({ a, b });
       }
     }
     return e;
   }, [nodes]);
 
-  function handleMove(e: React.MouseEvent<SVGCircleElement>, report: GraphReport) {
+  function handleMove(e: React.MouseEvent<SVGCircleElement>, cluster: GraphCluster) {
     if (!containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
     setHover({
-      report,
+      cluster,
       clientX: e.clientX - rect.left,
       clientY: e.clientY - rect.top,
     });
@@ -112,9 +100,8 @@ export default function ReportsGraph({ reports }: { reports: GraphReport[] }) {
         viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
         className="w-full h-[320px] bg-cream border border-rule rounded"
         role="img"
-        aria-label="Knowledge graph of regulatory research reports organized by topic and jurisdiction"
+        aria-label="Knowledge graph of regulatory subject clusters"
       >
-        {/* Topic anchor glows */}
         {Object.entries(TOPICS).map(([k, cfg]) => (
           <g key={k}>
             <circle cx={cfg.cx} cy={cfg.cy} r={44} fill={cfg.color} opacity={0.14} />
@@ -132,24 +119,22 @@ export default function ReportsGraph({ reports }: { reports: GraphReport[] }) {
           </g>
         ))}
 
-        {/* Orbit rings */}
         <g fill="none" stroke="#c9b88f" strokeWidth={0.6} opacity={0.7}>
           {Object.values(TOPICS).map((cfg, i) => (
             <circle key={i} cx={cfg.cx} cy={cfg.cy} r={cfg.radius} />
           ))}
         </g>
 
-        {/* Jurisdictional edges */}
         <g stroke="#9a8b72" strokeWidth={0.8} opacity={0.55} strokeDasharray="2,2">
           {edges.map(({ a, b }, i) => (
             <line key={i} x1={a.x} y1={a.y} x2={b.x} y2={b.y} />
           ))}
         </g>
 
-        {/* Report nodes */}
+        {/* Cluster nodes */}
         <g>
           {nodes.map((n) => {
-            const isHover = hover?.report.slug === n.slug;
+            const isHover = hover?.cluster.slug === n.slug;
             return (
               <circle
                 key={n.slug}
@@ -163,18 +148,18 @@ export default function ReportsGraph({ reports }: { reports: GraphReport[] }) {
                 onMouseEnter={(e) => handleMove(e, n)}
                 onMouseMove={(e) => handleMove(e, n)}
                 onMouseLeave={() => setHover(null)}
-                onClick={() => navigate(`/reports/${n.slug}`)}
+                onClick={() => navigate(`/reports/cluster/${n.slug}`)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    navigate(`/reports/${n.slug}`);
+                    navigate(`/reports/cluster/${n.slug}`);
                   }
                 }}
                 tabIndex={0}
                 role="button"
-                aria-label={`${n.title} — ${n.jurisdiction}, ${n.topic}, ${n.date}`}
+                aria-label={`${n.name} cluster — ${n.reports.length} reports`}
               >
-                <title>{n.title}</title>
+                <title>{n.name}</title>
               </circle>
             );
           })}
@@ -185,11 +170,10 @@ export default function ReportsGraph({ reports }: { reports: GraphReport[] }) {
         <ReportsGraphTooltip
           x={hover.clientX}
           y={hover.clientY}
-          title={hover.report.title}
-          topic={hover.report.topic}
-          jurisdiction={hover.report.jurisdiction}
-          date={hover.report.date}
-          summary={hover.report.summary}
+          name={hover.cluster.name}
+          topic={hover.cluster.topic}
+          reportCount={hover.cluster.reports.length}
+          summary={hover.cluster.summary}
         />
       )}
     </div>

--- a/src/components/reports/ReportsGraphTooltip.tsx
+++ b/src/components/reports/ReportsGraphTooltip.tsx
@@ -1,20 +1,18 @@
 type TooltipProps = {
   x: number;
   y: number;
-  title: string;
+  name: string;
   topic: string;
-  jurisdiction: string;
-  date: string;
+  reportCount: number;
   summary: string;
 };
 
 export default function ReportsGraphTooltip({
   x,
   y,
-  title,
+  name,
   topic,
-  jurisdiction,
-  date,
+  reportCount,
   summary,
 }: TooltipProps) {
   return (
@@ -26,11 +24,11 @@ export default function ReportsGraphTooltip({
         transform: "translate(-50%, calc(-100% - 12px))",
       }}
     >
-      <div className="font-semibold mb-0.5">{title}</div>
+      <div className="font-semibold mb-0.5">{name}</div>
       <div className="text-[10px] uppercase tracking-wider opacity-70 mb-1">
-        {jurisdiction} · {topic} · {date}
+        {topic} · {reportCount} {reportCount === 1 ? "report" : "reports"}
       </div>
-      <div className="line-clamp-3 opacity-90">{summary}</div>
+      {summary && <div className="line-clamp-3 opacity-90">{summary}</div>}
     </div>
   );
 }

--- a/src/components/reports/ReportsStatsBar.tsx
+++ b/src/components/reports/ReportsStatsBar.tsx
@@ -5,7 +5,12 @@ type Report = {
   jurisdiction: string;
 };
 
-export default function ReportsStatsBar({ reports }: { reports: Report[] }) {
+type Props = {
+  reports: Report[];
+  clusterCount: number;
+};
+
+export default function ReportsStatsBar({ reports, clusterCount }: Props) {
   const topics = new Set(reports.map((r) => r.topic));
   const jurisdictions = new Set(reports.map((r) => r.jurisdiction).filter((j) => j && j !== "Unknown"));
   const latest = reports.reduce((max, r) => (r.date > max ? r.date : max), "");
@@ -16,12 +21,13 @@ export default function ReportsStatsBar({ reports }: { reports: Report[] }) {
   const cards = [
     { big: reports.length.toString(), label: "reports" },
     { big: topics.size.toString(), label: "topics" },
+    { big: clusterCount.toString(), label: "clusters" },
     { big: jurisdictions.size.toString(), label: "jurisdictions" },
     { big: latestFormatted, label: "latest" },
   ];
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       {cards.map((c) => (
         <div
           key={c.label}

--- a/src/pages/ReportsCluster.tsx
+++ b/src/pages/ReportsCluster.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useDocumentTitle } from "@/hooks/use-document-title";
+
+type Report = {
+  slug: string;
+  title: string;
+  date: string;
+  topic: string;
+  jurisdiction: string;
+  summary: string;
+  cluster_slug?: string;
+};
+
+type Cluster = {
+  slug: string;
+  name: string;
+  topic: string;
+  summary: string;
+  reports: string[];
+  dateRange: { first: string; latest: string };
+  jurisdictions: string[];
+};
+
+type ReportsData = { memos: Report[]; clusters: Cluster[] };
+
+const TOPIC_DOT: Record<string, string> = {
+  privacy: "#9a6b3f",
+  cybersecurity: "#2d5c5c",
+  "ai-law": "#8a3a3a",
+};
+
+export default function ReportsCluster() {
+  const { slug } = useParams<{ slug: string }>();
+  const [cluster, setCluster] = useState<Cluster | null>(null);
+  const [reports, setReports] = useState<Report[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useDocumentTitle(
+    cluster ? `${cluster.name} | Rafal's Portfolio` : "Cluster | Rafal's Portfolio",
+  );
+
+  useEffect(() => {
+    setCluster(null);
+    setReports([]);
+    setNotFound(false);
+    setError(null);
+    window.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+
+    let cancelled = false;
+    fetch("/data/reports.json")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<ReportsData>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const found = data.clusters.find((c) => c.slug === slug);
+        if (!found) {
+          setNotFound(true);
+          return;
+        }
+        setCluster(found);
+        const members = data.memos
+          .filter((r) => found.reports.includes(r.slug))
+          .sort((a, b) => (a.date < b.date ? 1 : -1));
+        setReports(members);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  const dateRangeLabel = useMemo(() => {
+    if (!cluster) return "";
+    const { first, latest } = cluster.dateRange;
+    if (!first) return "";
+    return first === latest ? first : `${first} – ${latest}`;
+  }, [cluster]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-[720px] mx-auto px-4 py-10">
+        <Link to="/reports" className="text-sm text-muted-foreground hover:underline font-garamond">
+          ← All reports
+        </Link>
+
+        {error && <div className="text-destructive mt-6">Failed to load cluster: {error}</div>}
+        {notFound && <div className="mt-6 font-garamond">Cluster not found.</div>}
+        {!error && !notFound && !cluster && (
+          <div className="text-muted-foreground mt-6">Loading…</div>
+        )}
+
+        {cluster && (
+          <>
+            <header className="mt-6 mb-8">
+              <div className="text-[11px] uppercase tracking-widest text-primary font-garamond mb-3">
+                {cluster.topic} · {reports.length} {reports.length === 1 ? "report" : "reports"}
+                {dateRangeLabel && ` · ${dateRangeLabel}`}
+              </div>
+              <h1 className="text-4xl leading-tight font-garamond font-semibold tracking-tight">
+                {cluster.name}
+              </h1>
+              {cluster.summary && (
+                <aside className="mt-6 bg-cream border-l-[3px] border-l-primary border border-rule rounded-r px-5 py-4 italic text-muted-foreground font-garamond leading-relaxed">
+                  {cluster.summary}
+                </aside>
+              )}
+              {cluster.jurisdictions.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {cluster.jurisdictions.map((j) => (
+                    <span
+                      key={j}
+                      className="text-[10px] uppercase tracking-wider px-2 py-1 bg-cream border border-rule rounded font-garamond"
+                    >
+                      {j}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </header>
+
+            <div className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground font-garamond">
+              Reports in this cluster
+            </div>
+            <ul className="bg-cream border border-rule rounded divide-y divide-rule">
+              {reports.map((r) => (
+                <li key={r.slug}>
+                  <Link
+                    to={`/reports/${r.slug}`}
+                    className="block px-4 py-4 hover:bg-background transition"
+                  >
+                    <div className="flex items-baseline justify-between gap-4">
+                      <div className="flex items-center gap-2 flex-1">
+                        <span
+                          className="w-2 h-2 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: TOPIC_DOT[r.topic] || "#888" }}
+                          aria-hidden
+                        />
+                        <span className="text-sm font-garamond leading-snug">{r.title}</span>
+                      </div>
+                      <time className="text-xs text-muted-foreground font-garamond whitespace-nowrap">
+                        {r.date}
+                      </time>
+                    </div>
+                    <div className="text-xs text-muted-foreground font-garamond mt-1 ml-4">
+                      {r.jurisdiction}
+                    </div>
+                    {r.summary && (
+                      <div className="text-xs text-muted-foreground font-garamond mt-2 ml-4 line-clamp-2">
+                        {r.summary}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+
+            {reports.length === 1 && (
+              <p className="mt-4 text-xs text-muted-foreground font-garamond italic">
+                Only report in this cluster. More coming as this subject develops.
+              </p>
+            )}
+
+            <div className="mt-10">
+              <Link to="/reports" className="text-sm text-muted-foreground hover:underline font-garamond">
+                ← All reports
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ReportsIndex.tsx
+++ b/src/pages/ReportsIndex.tsx
@@ -2,10 +2,20 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import ReportsStatsBar from "@/components/reports/ReportsStatsBar";
-import ReportsGraph, { GraphReport } from "@/components/reports/ReportsGraph";
+import ReportsGraph, { GraphCluster } from "@/components/reports/ReportsGraph";
 
-type Report = GraphReport;
-type ReportsData = { memos: Report[] };
+type Report = {
+  slug: string;
+  title: string;
+  date: string;
+  topic: string;
+  jurisdiction: string;
+  summary: string;
+  cluster?: string;
+  cluster_slug?: string;
+};
+
+type ReportsData = { memos: Report[]; clusters: GraphCluster[] };
 
 const TOPICS = ["all", "privacy", "cybersecurity", "ai-law"] as const;
 type Topic = (typeof TOPICS)[number];
@@ -34,15 +44,31 @@ export default function ReportsIndex() {
   }, []);
 
   const allReports = data?.memos ?? [];
+  const allClusters = data?.clusters ?? [];
 
-  const filtered = useMemo(() => {
+  const filteredReports = useMemo(() => {
     const q = query.trim().toLowerCase();
     return allReports.filter((r) => {
       if (topic !== "all" && r.topic !== topic) return false;
-      if (q && !(r.title + " " + r.summary).toLowerCase().includes(q)) return false;
+      if (q) {
+        const haystack = `${r.title} ${r.summary} ${r.cluster || ""}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
       return true;
     });
   }, [allReports, topic, query]);
+
+  const filteredClusters = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allClusters.filter((c) => {
+      if (topic !== "all" && c.topic !== topic) return false;
+      if (q) {
+        const haystack = `${c.name} ${c.summary}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [allClusters, topic, query]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -61,7 +87,7 @@ export default function ReportsIndex() {
 
         {data && (
           <>
-            <ReportsStatsBar reports={allReports} />
+            <ReportsStatsBar reports={allReports} clusterCount={allClusters.length} />
 
             <div className="flex flex-wrap gap-2 mb-4 items-center">
               {TOPICS.map((t) => (
@@ -81,15 +107,15 @@ export default function ReportsIndex() {
               ))}
               <input
                 type="search"
-                placeholder="Search reports…"
+                placeholder="Search clusters and reports…"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                className="flex-1 min-w-[160px] px-3 py-1 text-xs rounded-full border border-border bg-background font-garamond focus:outline-none focus:ring-2 focus:ring-ring"
+                className="flex-1 min-w-[200px] px-3 py-1 text-xs rounded-full border border-border bg-background font-garamond focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
 
             <div className="hidden md:block mb-6">
-              <ReportsGraph reports={filtered} />
+              <ReportsGraph clusters={filteredClusters} />
             </div>
 
             <div className="mb-2 flex items-baseline justify-between">
@@ -100,13 +126,13 @@ export default function ReportsIndex() {
               <div className="text-[11px] text-muted-foreground">sorted by date ↓</div>
             </div>
 
-            {filtered.length === 0 ? (
+            {filteredReports.length === 0 ? (
               <div className="text-muted-foreground text-sm border border-rule rounded p-6 text-center">
                 No reports match.
               </div>
             ) : (
               <ul className="bg-cream border border-rule rounded divide-y divide-rule">
-                {filtered.map((r) => (
+                {filteredReports.map((r) => (
                   <li key={r.slug}>
                     <Link
                       to={`/reports/${r.slug}`}


### PR DESCRIPTION
…vidual reports

Graph nodes now represent clusters (e.g. 'TAKE IT DOWN Act') produced by the Zwiad pipeline's LLM classifier. Each cluster has an AI-written subject summary and its own landing page at /reports/cluster/<slug> listing the member reports.

- ReportsGraph: nodes = clusters, size = report count, orbits by cluster's primary topic, edges by jurisdictional overlap
- ReportsGraphTooltip: cluster-shaped (name, topic, report count, summary)
- ReportsStatsBar: adds 'clusters' stat between topics and jurisdictions
- ReportsCluster (new): landing page per cluster — summary pull-quote, jurisdiction chips, list of member reports
- ReportsIndex: search now matches cluster names too
- build-reports.ts: fetches clusters.json, carries cluster_slug/name through per-report, emits {memos, clusters} together